### PR TITLE
feat: comments are mapped to posts on f.e. + b.e.

### DIFF
--- a/frontend/src/components/Comments.tsx
+++ b/frontend/src/components/Comments.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
 import { getPostComments } from '../utils/axios/commentAPIs'
 
 
@@ -10,25 +11,35 @@ postId: any
 const Comments = ({postId}: Props) => {
 
 const [comments, setComments] = useState([])
+const [loading, setLoading] = useState(true)
+const navigate = useNavigate()
+
 
 useEffect(() => {
-getPostComments(postId).then((res) => {setComments(res)
-console.log(res)})
+getPostComments(postId).then((res) => { 
+setComments(res[0].comments)
+setLoading(false)}
+)
 
 }, [])
 
-  return (
-    <div>
-{/* {comments.map((comment: any) => {
-return (
-<div key={comment._id}>
-<img src={comment.postedBy.profilePic}/>
-<h1>{comment.postedBy.userName}</h1>
-<h1>{comment.comment}</h1>
-</div>
-)})} */}
 
-<button type='button' onClick={() => console.log(comments)}>Test</button>
+if(loading){
+  return <h1>Loading comments...</h1>
+}
+
+  return (
+    <div className='pt-2'>
+{comments.map((comment: any) => {
+return (
+<div key={comment._id} className='flex text-sm gap-2'>
+{/* <img className='w-[12px] h-[12px] rounded-full'src={comment.postedBy.profilePic}/> */}
+<h1 onClick={() => navigate(`profile/${comment.postedBy.userName}`)} className='font-semibold cursor-pointer'>{comment.postedBy.userName}</h1>
+<h1 className=''>{comment.comment}</h1>
+</div>
+)})}
+
+{/* <button type='button' onClick={() => console.log(comments)}>Test</button> */}
 
     </div>
 )

--- a/frontend/src/components/Post.tsx
+++ b/frontend/src/components/Post.tsx
@@ -114,7 +114,7 @@ isOnFeed ? (
       </div>
       <CommentForm postId={post._id} isOpen={commentIsOpen} />
       <Comments postId={post._id} />
-      <h3 className='text-xs text-gray-500 mt-2'>{formattedDate}</h3>
+      <h2 className='text-xs text-gray-500 mt-2'>{formattedDate}</h2>
       </div>
     </div>
   ) : (


### PR DESCRIPTION
Comments now show up under each post with appropriate styling, on username click it navigates to the users profile, similar to how it does in the real thing.

One thing to note, is there is no like functionality for comments (tbd if I implement this) and the comments do not get put into a 'view all comments' section if there is more than 2-3, instead it will list them endlessly.