### PR TITLE
Feature/delete+edit own posts

### DIFF
--- a/backend/controllers/post.js
+++ b/backend/controllers/post.js
@@ -46,8 +46,17 @@ export const uploadContentToCloudinary = (req, res) => {
 export const deletePost = async (req, res) => {
 
     try{
+        const postedBy = await Post.findById(req.params.postid).select('postedBy')
+        // console.log(postedBy.postedBy)
+        if(postedBy.postedBy == req.user){
         await Post.findByIdAndDelete(req.params.postid)
-        res.status(200).json('Post Deleted')
+        await User.findByIdAndUpdate(req.user, { $pull: {posts: req.params.postid}, $inc: {postCount: -1}})
+        res.status(200).json('Posted deleted')
+        }
+
+        else {
+        res.json('Cannot delete somebody elses post.')
+        }
     } catch (err) {
         throw err
     }
@@ -57,8 +66,15 @@ export const deletePost = async (req, res) => {
 // Edit post caption only, not photo/video
 export const editPostCaption = async (req, res) => {
 try {
+
+    const postedBy = await Post.findById(req.params.postid).select('postedBy')
+    if(postedBy.postedBy == req.user){
     const post = await Post.findByIdAndUpdate(req.params.postid, { $set: { caption: req.body.caption}}, {new: true})
     res.status(200).json(post)
+    }
+    else {
+        console.log('Cannot edit a post if it is not yours.')
+    }
 } catch (err) {
     console.log(err)
 }

--- a/backend/controllers/post.js
+++ b/backend/controllers/post.js
@@ -46,11 +46,7 @@ export const uploadContentToCloudinary = (req, res) => {
 export const deletePost = async (req, res) => {
 
     try{
-        await Post.deleteOne({
-            _id: req.params.id
-        }, {
-            new: true
-        })
+        await Post.findByIdAndDelete(req.params.postid)
         res.status(200).json('Post Deleted')
     } catch (err) {
         throw err
@@ -59,7 +55,13 @@ export const deletePost = async (req, res) => {
 }
 
 // Edit post caption only, not photo/video
-export const editPost = async (req, res) => {
+export const editPostCaption = async (req, res) => {
+try {
+    const post = await Post.findByIdAndUpdate(req.params.postid, { $set: { caption: req.body.caption}}, {new: true})
+    res.status(200).json(post)
+} catch (err) {
+    console.log(err)
+}
 
 
 }

--- a/backend/routes/post.js
+++ b/backend/routes/post.js
@@ -1,5 +1,5 @@
 import express from 'express'
-import { checkIfLiked, createPost, deletePost, getAllPosts, getPostById, getSubscribedPosts, likePostToggle, uploadContentToCloudinary } from '../controllers/post.js'
+import { checkIfLiked, createPost, deletePost, editPostCaption, getAllPosts, getPostById, getSubscribedPosts, likePostToggle, uploadContentToCloudinary } from '../controllers/post.js'
 import cors from 'cors'
 import { requireLogin } from '../utils/auth.js'
 import { multerUploads } from '../utils/multer.js'
@@ -10,12 +10,16 @@ router.use(cors())
 router.get('/getallposts', getAllPosts)
 router.get('/:postid', getPostById)
 router.post('/upload', multerUploads.single('image'), uploadContentToCloudinary) 
+
+
 router.use(requireLogin)
 router.get('/getsubscribedposts', getSubscribedPosts)
+
+router.post('/createpost', createPost)
 router.post('/:postid/togglelike', likePostToggle)
 router.get('/:postid/checklikes', checkIfLiked)
-router.post('/createpost', createPost)
-router.delete('/deletepost', deletePost)
+router.delete('/:postid/deletepost', deletePost)
+router.put('/:postid/editpost', editPostCaption)
 
 
 export default router

--- a/frontend/src/components/EditPostModal.tsx
+++ b/frontend/src/components/EditPostModal.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+type Props = {
+
+isOpen: boolean,
+
+}
+
+const EditPostModal = ({isOpen}: Props) => {
+  return (
+    <div>
+      <button type='button' className=''>Delete Post</button>
+    </div>
+  )
+}
+
+export default EditPostModal

--- a/frontend/src/components/EditPostModal.tsx
+++ b/frontend/src/components/EditPostModal.tsx
@@ -1,20 +1,63 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { deletePost, editPost } from '../utils/axios/postAPIs'
 
 type Props = {
 
 isOpen: boolean,
+postId: any,
+postCaption: string,
 
 }
 
-const EditPostModal = ({isOpen}: Props) => {
+const EditPostModal = ({isOpen, postId, postCaption}: Props) => {
+
+const [currentTab, setCurrentTab] = useState('')
+const [caption, setCaption] = useState(postCaption)
+
+const handleCaptionEdit = async () => {
+
+await editPost(postId, caption).then(res => console.log(res))
+setCurrentTab('')
+
+
+}
+
+const handlePostDelete = async () => {
+
+await deletePost(postId).then(res => window.alert('Post Successfully Deleted'))
+
+}
+
+
   return (
   
     <>
     {isOpen ?
-    <div className='bg-white rounded-xl absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 h-1/2 w-1/2'>
-    <div className='mx-6 text-center'>
-    <h1 className='font-semibold outline outline-gray-50 py-1 my-4 bg-blue-400 hover:bg-blue-500 text-white hover:text-black cursor-pointer rounded-md'>Edit Post</h1>
-    <h1 className='font-semibold bg-red-400 hover:bg-red-500 py-1 text-white hover:text-black cursor-pointer rounded-md'>Delete Post</h1>
+    <div className={currentTab == '' ? `bg-white rounded-xl absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 h-1/2 w-1/2` : `bg-white rounded-xl absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 h-1/2 w-full flex`}>
+    <div className={currentTab == '' ? `mx-6 text-center flex flex-col` : `mx-6 text-center flex flex-col`}>
+    <button type='button' onClick={() => setCurrentTab('edit')}className='font-semibold py-1 px-12 my-4 bg-blue-400 hover:bg-blue-500 text-white hover:text-black cursor-pointer rounded-md'>Edit</button>
+    <button type='button' onClick={() => setCurrentTab('delete')}className='font-semibold bg-red-400 hover:bg-red-500 py-1 text-white hover:text-black cursor-pointer rounded-md'>Delete Post</button>
+    </div>
+    <div className={currentTab == '' ? `hidden` : `bg-white rounded-xl w-full relative`}>
+        <h1 className='absolute text-gray-400 right-3 top-2 font-bold hover:text-red-500 hover:cursor-pointer' onClick={() => setCurrentTab('')}>X</h1>
+        <div className='pt-8'>
+        {currentTab == 'edit' && (
+        <div className='w-full px-2'>
+          <h1 className='text-center font-semibold'>Edit Post Caption</h1>  
+          <textarea className='w-full border outline-none' placeholder={postCaption} value={caption} onChange={(e) => setCaption(e.target.value)}/>
+          <button type='button' className='font-semibold py-1 px-12 my-4 bg-orange-400 hover:bg-orange-500 text-white cursor-pointer rounded-md' onClick={handleCaptionEdit}>Confirm Edit</button>
+        </div>
+        )}
+         {currentTab == 'delete' && (
+        <div>
+        <h1>Are you sure you want to delete this post?</h1>
+        <div className='flex gap-4 mx-6'>
+        <button type='button' className='font-semibold py-1 px-3 my-4 bg-blue-400 hover:bg-blue-500 text-white hover:text-black cursor-pointer rounded-md' onClick={handlePostDelete}>Delete post</button> 
+        <button type='button' className='font-semibold py-1 px-3 my-4 bg-blue-400 hover:bg-blue-500 text-white hover:text-black cursor-pointer rounded-md' onClick={() => setCurrentTab('')}>Cancel</button> 
+        </div>
+        </div>
+        )}
+        </div>
     </div>
     </div>
 

--- a/frontend/src/components/EditPostModal.tsx
+++ b/frontend/src/components/EditPostModal.tsx
@@ -8,9 +8,19 @@ isOpen: boolean,
 
 const EditPostModal = ({isOpen}: Props) => {
   return (
-    <div>
-      <button type='button' className=''>Delete Post</button>
+  
+    <>
+    {isOpen ?
+    <div className='bg-white rounded-xl absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 h-1/2 w-1/2'>
+    <div className='mx-6 text-center'>
+    <h1 className='font-semibold outline outline-gray-50 py-1 my-4 bg-blue-400 hover:bg-blue-500 text-white hover:text-black cursor-pointer rounded-md'>Edit Post</h1>
+    <h1 className='font-semibold bg-red-400 hover:bg-red-500 py-1 text-white hover:text-black cursor-pointer rounded-md'>Delete Post</h1>
     </div>
+    </div>
+
+    : null}
+    
+    </>
   )
 }
 

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -38,31 +38,31 @@ const { logout } = logoutUser()
     <div className='text-xl px-4 mx-auto h-full pt-8'>
     <Link to={'/'} className='pl-2 flex gap-4 py-2 my-2 hover:bg-gray-50 hover:rounded-full'> 
     <HomeSelected />
-    <h1>Home</h1>
+    <h1 className='invisible sm:visible'>Home</h1>
     </Link>
     <ul className='pl-2 flex gap-4 py-2 my-2 hover:bg-gray-50 hover:rounded-full'>
     <SearchBtnIcon />    
-    <h1>Search</h1>
+    <h1 className='invisible sm:visible'>Search</h1>
     </ul>
     <Link to={''} className='pl-2 flex gap-4 py-2 my-2 hover:bg-gray-50 hover:rounded-full'>
     <ExploreUnselected />
-    <h1>Explore</h1>
+    <h1 className='invisible sm:visible'>Explore</h1>
     </Link>
     <Link to={''} className='pl-2 flex gap-4 py-2 my-2 hover:bg-gray-50 hover:rounded-full'>
     <MessageUnselected />
-    <h1>Messages</h1>
+    <h1 className='invisible sm:visible'>Messages</h1>
     </Link>
     <ul className='pl-2 flex gap-4 py-2 my-2 hover:bg-gray-50 hover:rounded-full'>
     <NotificationsUnselected />
-    <h1>Notifications</h1>
+    <h1 className='invisible sm:visible'>Notifications</h1>
     </ul>
     <ul className='pl-2 flex gap-4 py-2 my-2 cursor-pointer hover:bg-gray-50 hover:rounded-full' onClick={() => setIsOpen(!isOpen)}>
     <CreateUnselected />
-    <h1>Create</h1>
+    <h1 className='invisible sm:visible'>Create</h1>
     </ul>
     <Link to={`/profile/${profile.userName}`} className='flex gap-4 py-2 my-2 pl-2 hover:bg-gray-50 hover:rounded-full'>
     <img className='w-[32px] h-[32px] rounded-full' src={profile.profilePic}/>
-    <h1>{profile.userName}</h1>
+    <h1 className='invisible sm:visible'>{profile.userName}</h1>
     </Link>
     <div className='py-24'>
     {/* <button onClick={() => getSubscribedPosts().then((res) => {

--- a/frontend/src/components/Post.tsx
+++ b/frontend/src/components/Post.tsx
@@ -24,7 +24,10 @@ const [isLiked, setIsLiked] = useState(false)
 const [commentIsOpen, setCommentIsOpen] = useState(false)
 
 useEffect(() => {
-checkIfLikedByUser(post._id).then(res => setIsLiked(res))
+checkIfLikedByUser(post._id).then(res => {
+  setIsLiked(res)
+})
+
 }, [])
 
 const navigate = useNavigate()
@@ -32,25 +35,6 @@ const navigate = useNavigate()
 
 const likeList = post.likes
 const likes = post.likes.map((liker: any) => {
-
-// switch (likeList.length) {
-
-//   case likeList.length == 0:
-//     <h1>Be the first to like this post!</h1>
-//     break
-  
-//   case likeList.length == 1:
-//     <span className='font-semibold cursor-pointer pl-1' onClick={() => {navigate(`/profile/${liker.userName}`)}}>{liker.userName}</span>
-//     break
-
-//   case likeList.length > 1 && likeList.length <= 3:
-//     <span className='font-semibold cursor-pointer pl-1' onClick={() => {navigate(`/profile/${liker.userName}`)}}>{liker.userName},</span>
-//     break
-
-//   case likeList.length >= 4:
-//     <span className='font-semibold cursor-pointer pl-1' onClick={() => {navigate(`/profile/${liker.userName}`)}}>{liker.userName}</span>
-//     break
-// }
 
 
 if(likeList.length === 0){
@@ -81,10 +65,17 @@ else if (likeList.length >= 4 ){
 return (
 isOnFeed ? (
     <div key={post._id} className='border rounded-xl'>
-      <Link to={`/profile/${post.postedBy.userName}`} className='flex gap-3 my-auto py-3 border-b pl-4'>
+      <div className='flex justify-between border-b '>
+      <div>
+      <Link to={`/profile/${post.postedBy.userName}`} className='flex gap-3 my-auto py-3 pl-4'>
         <img className='w-10 h-10 rounded-full' src={post.postedBy.profilePic}/>
         <h1 className='my-auto font-semibold'>{post.postedBy.userName}</h1>
       </Link>
+      </div>
+      <div className='my-2 mr-4'>
+        <h1 className='text-3xl font-semibold cursor-pointer'>...</h1>
+      </div>
+      </div>
       <div>
       <img className='w-[468px] h-[468px] object-fill border-b' src={post.photo} />
       </div>

--- a/frontend/src/components/Post.tsx
+++ b/frontend/src/components/Post.tsx
@@ -76,7 +76,7 @@ isOnFeed ? (
       </div>
       <div className='my-2 mr-4'>
         <h1 className='text-3xl font-semibold cursor-pointer' onClick={() => setEditModalIsOpen(!editModalIsOpen)}>...</h1>
-        <EditPostModal isOpen={editModalIsOpen}/>
+        <EditPostModal isOpen={editModalIsOpen} postId={post._id} postCaption={post.caption}/>
       </div>
       </div>
       <div>

--- a/frontend/src/components/Post.tsx
+++ b/frontend/src/components/Post.tsx
@@ -9,6 +9,7 @@ import CommentForm from './CommentForm'
 import { checkIfLikedByUser, likePostToggle } from '../utils/axios/postAPIs'
 import { getProfileId } from '../utils/axios/profileAPIs'
 import Comments from './Comments'
+import EditPostModal from './EditPostModal'
 
 type Props = {
   isOnFeed: boolean,
@@ -22,6 +23,7 @@ const formattedDate = dayjs(post.createdAt).format(`MMMM D`)
 
 const [isLiked, setIsLiked] = useState(false)
 const [commentIsOpen, setCommentIsOpen] = useState(false)
+const [editModalIsOpen, setEditModalIsOpen] = useState(false)
 
 useEffect(() => {
 checkIfLikedByUser(post._id).then(res => {
@@ -64,7 +66,7 @@ else if (likeList.length >= 4 ){
 
 return (
 isOnFeed ? (
-    <div key={post._id} className='border rounded-xl'>
+    <div key={post._id} className='border rounded-xl relative'>
       <div className='flex justify-between border-b '>
       <div>
       <Link to={`/profile/${post.postedBy.userName}`} className='flex gap-3 my-auto py-3 pl-4'>
@@ -73,7 +75,8 @@ isOnFeed ? (
       </Link>
       </div>
       <div className='my-2 mr-4'>
-        <h1 className='text-3xl font-semibold cursor-pointer'>...</h1>
+        <h1 className='text-3xl font-semibold cursor-pointer' onClick={() => setEditModalIsOpen(!editModalIsOpen)}>...</h1>
+        <EditPostModal isOpen={editModalIsOpen}/>
       </div>
       </div>
       <div>

--- a/frontend/src/utils/axios/postAPIs.ts
+++ b/frontend/src/utils/axios/postAPIs.ts
@@ -73,3 +73,27 @@ export const checkIfLikedByUser = async (postId: any) => {
     
     }
 
+export const deletePost = async (postId: any) => {
+try{
+const deletePost = await axios.delete(`${baseURL}${postURL}/${postId}/deletepost`).then(res => console.log(res.data))
+return deletePost
+
+} catch(err){
+    console.log(err)
+}
+}
+
+export const editPost = async (postId: any, caption: string) => {
+
+try{
+const editPost = await axios.put(`${baseURL}${postURL}/${postId}/editpost`, {
+    caption: caption
+}).then(res => console.log(res))
+return editPost
+
+} catch (err) {
+    console.log(err)
+}
+
+}
+


### PR DESCRIPTION
Users can now edit and delete their own posts, but in doing so, given the class tweaks, the post create modal is now buggy as it displays under the post component vs overlaying it - this is pretty bad, although you can work around it with changing window sizes.

The ellipsis displays over each post and the modal pops up for each post even if it is not the original users, but the edit and delete feature does not work (coded into the backend). Will need to work on dynamically displaying this feature only on posts that belong to the signed in user.

Furthermore, the modal expands into multiple parts so user can edit and delete with dynamically changing modal.