### PR TITLE
feat: posts can now be displayed by id

### DIFF
--- a/backend/controllers/post.js
+++ b/backend/controllers/post.js
@@ -105,6 +105,8 @@ export const getSubscribedPosts = async (req, res) => {
 
 export const getPostById = async (req, res) => {
 
+const post = await Post.findById(req.params.postid).populate('postedBy').populate({path: 'likes', select: 'userName profilePic'})
+return res.status(200).json(post)
 
 
 }

--- a/backend/routes/post.js
+++ b/backend/routes/post.js
@@ -8,7 +8,7 @@ const router = express.Router()
 router.use(cors())
 
 router.get('/getallposts', getAllPosts)
-router.get('/:postid', getPostById)
+router.get('/post/:postid', getPostById)
 router.post('/upload', multerUploads.single('image'), uploadContentToCloudinary) 
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import Login from "./pages/Login";
 import Profile from "./pages/Profile";
 import { useUserContext } from "./hooks/useUserContext.js";
 import EditProfile from "./pages/EditProfile";
+import SinglePost from "./pages/SinglePost";
 
 function App(): any {
 
@@ -21,6 +22,7 @@ const { user } = useUserContext()
       <Route path='/profile/:username' element={<Profile />}/>
       <Route path='/accounts/edit' element={<EditProfile />} />
       <Route path='*' element={<Navigate to="/" />}/>
+      <Route path='/post/:postid' element={<SinglePost />} />
     </Routes>
     </BrowserRouter>
     </>

--- a/frontend/src/components/Post.tsx
+++ b/frontend/src/components/Post.tsx
@@ -117,7 +117,7 @@ isOnFeed ? (
 <h1 className='hover:visible text-white font-bold mx-auto my-auto'>{post.numberOfLikes}</h1>
 <h1 className='hover:visible text-white font-bold mx-auto my-auto'>{post.numberOfComments}</h1>
 </div> */}
-<div key={post._id} className='my-6 cursor-pointer hover:opacity-25'>
+<div key={post._id} className='my-6 cursor-pointer hover:opacity-25' onClick={() => navigate(`/post/${post._id}`)}>
 <img className='h-[256px] w-[256px]' src={post.photo}/>
 </div>
 </div>

--- a/frontend/src/pages/SinglePost.tsx
+++ b/frontend/src/pages/SinglePost.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react'
+import { useParams } from 'react-router'
+import Navbar from '../components/Navbar'
+import Post from '../components/Post'
+import { getPostById } from '../utils/axios/postAPIs'
+
+const SinglePost = () => {
+
+const { postid } = useParams()
+const [post, setPost] = useState([])
+const [loading, setLoading] = useState(true)
+
+useEffect(() => {
+getPostById(postid).then((res: any) => setPost(res)).then(res => setLoading(false))
+}, [])
+
+  return (
+    <div className='flex'>
+        <Navbar />
+        <div className='my-auto mx-auto w-1/2 h-2/3'>
+        { loading ? <p>Loading</p> :
+        <>
+        {/* <button onClick={() => console.log(post)}>Test Button For Post Data</button> */}
+        <Post isOnFeed={true} post={post} />
+        </>
+        }
+        </div>
+        
+        
+    </div>
+  )
+}
+
+export default SinglePost

--- a/frontend/src/utils/axios/postAPIs.ts
+++ b/frontend/src/utils/axios/postAPIs.ts
@@ -97,3 +97,16 @@ return editPost
 
 }
 
+export const getPostById = async (postId: any) => {
+
+try {
+const getPost = await axios.get(`${baseURL}${postURL}/post/${postId}`)
+return getPost.data
+} catch(err) {
+
+    console.log(err)
+
+}
+
+}
+


### PR DESCRIPTION
Added the ability to view individual posts by their ID. This is primarily useful because you can now click on the posts that are displayed on each profile and it will navigate you to a separate page and it reuses the Post component via props to display the post.